### PR TITLE
Fix JDK8 install error on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ install: true
 script:
 - ./mvnw clean verify
 
-# Fix 'Expected feature release number in range of 9 to 14' error on xenial
-dist: bionic
+# Fix 'Expected feature release number in range of 9 to 14' error on xenial and bionic
+dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,6 @@ install: true
 
 script:
 - ./mvnw clean verify
+
+# Fix 'Expected feature release number in range of 9 to 14' error on xenial
+dist: bionic


### PR DESCRIPTION
Most workarounds suggested downgrading to trusty (14.04), but one mentioned that the problem is specific to xenial (16.04), so hopefully 18.04 will work.