### PR TITLE
Update docs and comments to Java 8 as minimum

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@ https://github.com/ec4j/editorconfig-maven-plugin/issues[report] them :)
 
 == Basic usage
 
-`editorconfig-maven-plugin` requires Java 7+ and Maven 3.3.1+.
+`editorconfig-maven-plugin` requires Java 8+ and Maven 3.3.1+.
 
 To make the build fail if any of your source files does not comply with `.editorconfig` rules, add the following to your project:
 
@@ -101,7 +101,7 @@ duplicate work.
 
 Prerequisites:
 
-* Java 7+
+* Java 8+
 * Optionally Maven 3.5.0+, unless you want to use `./mvnw` or `mvnw.bat` delivered by the project
 
 The most common build with unit tests:

--- a/editorconfig-maven-plugin/src/main/java/org/ec4j/maven/Slf4jLintLogger.java
+++ b/editorconfig-maven-plugin/src/main/java/org/ec4j/maven/Slf4jLintLogger.java
@@ -25,25 +25,20 @@ import org.ec4j.lint.api.Logger;
  */
 public class Slf4jLintLogger extends Logger.AbstractLogger {
     static LogLevelSupplier toEc4jLogLevelSupplier(final org.slf4j.Logger log) {
-        return new LogLevelSupplier() {
-
-            @Override
-            public LogLevel getLogLevel() {
-                if (log.isTraceEnabled()) {
-                    return LogLevel.TRACE;
-                } else if (log.isDebugEnabled()) {
-                    return LogLevel.DEBUG;
-                } else if (log.isInfoEnabled()) {
-                    return LogLevel.INFO;
-                } else if (log.isWarnEnabled()) {
-                    return LogLevel.WARN;
-                } else if (log.isErrorEnabled()) {
-                    return LogLevel.ERROR;
-                } else {
-                    return LogLevel.NONE;
-                }
+        return () -> {
+            if (log.isTraceEnabled()) {
+                return LogLevel.TRACE;
+            } else if (log.isDebugEnabled()) {
+                return LogLevel.DEBUG;
+            } else if (log.isInfoEnabled()) {
+                return LogLevel.INFO;
+            } else if (log.isWarnEnabled()) {
+                return LogLevel.WARN;
+            } else if (log.isErrorEnabled()) {
+                return LogLevel.ERROR;
+            } else {
+                return LogLevel.NONE;
             }
-
         };
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,6 @@
     <version.formatter-maven-plugin>2.11.0</version.formatter-maven-plugin>
     <version.com.github.github.site-maven-plugin>0.12</version.com.github.github.site-maven-plugin>
     <version.com.mycila.license-maven-plugin>3.0</version.com.mycila.license-maven-plugin>
-    <!-- 1.11.12 is the last takari lifecycle version supporting Java 7 -->
     <version.io.takari.maven.plugins.takari-lifecycle-plugin>1.13.9</version.io.takari.maven.plugins.takari-lifecycle-plugin>
     <version.impsort-maven-plugin>1.3.2</version.impsort-maven-plugin>
     <version.maven-antrun-plugin>1.8</version.maven-antrun-plugin>


### PR DESCRIPTION
Since GitHub Actions tests against Java 8 as minimum, the code and docs should also require Java 8 as a minimum version