### PR TITLE
Prints "Skipping execution" as INFO

### DIFF
--- a/editorconfig-maven-plugin/src/main/java/org/ec4j/maven/AbstractEditorConfigMojo.java
+++ b/editorconfig-maven-plugin/src/main/java/org/ec4j/maven/AbstractEditorConfigMojo.java
@@ -204,7 +204,7 @@ public abstract class AbstractEditorConfigMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (skip) {
-            log.debug("Skipping execution, as demanded by user.");
+            log.info("Skipping execution, as demanded by user.");
             return;
         }
 


### PR DESCRIPTION
It is common for plugins to report in the log when their execution is skipped. I changed the message from DEBUG to INFO so that this occurs without any extra log configuration.